### PR TITLE
Change the way we check query execution status

### DIFF
--- a/src/Abuse/Abuse.php
+++ b/src/Abuse/Abuse.php
@@ -45,14 +45,14 @@ class Abuse
     }
 
     /**
-     * Delete all logs older than $seconds seconds
+     * Delete all logs older than $timestamp seconds
      *
-     * @param int $seconds
+     * @param int $timestamp
      * 
      * @return bool
      */
-    public function cleanup(int $seconds): bool
+    public function cleanup(int $timestamp): bool
     {
-        return $this->adapter->cleanup($seconds);
+        return $this->adapter->cleanup($timestamp);
     }
 }

--- a/src/Abuse/Adapter.php
+++ b/src/Abuse/Adapter.php
@@ -27,11 +27,11 @@ interface Adapter
 
 
     /**
-     * Delete all logs older than $seconds seconds
+     * Delete all logs older than $timestamp seconds
      *
-     * @param int $seconds
+     * @param int $timestamp
      * 
      * @return bool
      */
-    public function cleanup(int $seconds): bool;
+    public function cleanup(int $timestamp): bool;
 }

--- a/src/Abuse/Adapters/ReCaptcha.php
+++ b/src/Abuse/Adapters/ReCaptcha.php
@@ -82,14 +82,14 @@ class ReCaptcha implements Adapter
     }
 
     /**
-     * Delete logs older than $seconds seconds
+     * Delete logs older than $timestamp seconds
      * 
-     * @param int $seconds 
+     * @param int $timestamp 
      * 
      * @throws Exception
      * @return bool   
      */
-    public function cleanup(int $seconds):bool
+    public function cleanup(int $timestamp):bool
     {
         throw new Exception('Method not supported');
     }

--- a/src/Abuse/Adapters/TimeLimit.php
+++ b/src/Abuse/Adapters/TimeLimit.php
@@ -228,22 +228,22 @@ class TimeLimit implements Adapter
 
 
     /**
-     * Delete logs older than $seconds seconds
+     * Delete logs older than $timestamp seconds
      * 
-     * @param int $seconds 
+     * @param int $timestamp 
      * 
      * @return bool   
      */
-    public function cleanup(int $seconds):bool
+    public function cleanup(int $timestamp):bool
     {
         $st = $this->getPDO()->prepare('DELETE 
         FROM `'.$this->getNamespace().'.abuse.abuse`
-            WHERE (UNIX_TIMESTAMP(NOW()) - CAST(`_time` AS SIGNED)) > :seconds');
+            WHERE `_time` < :timestamp');
 
-        $st->bindValue(':seconds', $seconds, PDO::PARAM_INT);
-        $st->execute();
+        $st->bindValue(':timestamp', $timestamp, PDO::PARAM_INT);
+        $result = $st->execute();
 
-        return ('00000' == $st->errorCode()) ? true : false;
+        return $result == true; 
     }
     
     /**

--- a/tests/Abuse/AbuseTest.php
+++ b/tests/Abuse/AbuseTest.php
@@ -77,7 +77,7 @@ class AbuseTest extends TestCase
         
         sleep(5);
         // Delete the log 
-        $status = $this->abuse->cleanup(1);
+        $status = $this->abuse->cleanup(time()-1);
         $this->assertEquals($status, true);
 
         // Check that there are no logs in the DB


### PR DESCRIPTION
The right way to check for query execution status is by using the response from $st->execute()