### PR TITLE
Allow custom score thresholds for reCAPTCHA

### DIFF
--- a/src/Abuse/Adapters/ReCaptcha.php
+++ b/src/Abuse/Adapters/ReCaptcha.php
@@ -58,7 +58,7 @@ class ReCaptcha implements Adapter
      *
      * @return bool
      */
-    public function check($score):bool
+    public function check($score = 0.5):bool
     {
         $url    = 'https://www.google.com/recaptcha/api/siteverify';
         $fields = array(

--- a/src/Abuse/Adapters/ReCaptcha.php
+++ b/src/Abuse/Adapters/ReCaptcha.php
@@ -53,8 +53,12 @@ class ReCaptcha implements Adapter
      * Check
      *
      * Check if user is human or not
+     *
+     * @param float $score
+     *
+     * @return bool
      */
-    public function check()
+    public function check($score):bool
     {
         $url    = 'https://www.google.com/recaptcha/api/siteverify';
         $fields = array(
@@ -77,8 +81,11 @@ class ReCaptcha implements Adapter
 
         //close connection
         \curl_close($ch);
-
-        return $result['success'];
+        if ($result['success'] && $result['score'] < $score ) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**

--- a/src/Abuse/Adapters/ReCaptcha.php
+++ b/src/Abuse/Adapters/ReCaptcha.php
@@ -52,10 +52,9 @@ class ReCaptcha implements Adapter
     /**
      * Check
      *
-     * Check if user is human or not
+     * Check if user is human or not, compared to score
      *
      * @param float $score
-     *
      * @return bool
      */
     public function check($score = 0.5):bool


### PR DESCRIPTION
With reCAPTCHA v3, each the server-side check has the following response model:
```
{
  "success": true|false,      // whether this request was a valid reCAPTCHA token for your site
  "score": number             // the score for this request (0.0 - 1.0)
  "action": string            // the action name for this request (important to verify)
  "challenge_ts": timestamp,  // timestamp of the challenge load (ISO format yyyy-MM-dd'T'HH:mm:ssZZ)
  "hostname": string,         // the hostname of the site where the reCAPTCHA was solved
  "error-codes": [...]        // optional
}
```
Since v3 implements a scoring system of `0.0 < x < 1.0`, the `success` field no longer represents the bot check, but only if the provided token is valid.

This PR allows the `check()` method to accept a `$score` float parameter and will return the `success` bool as expected. The Google-suggested default is `x=0.5`.