### PR TITLE
Doc: Wrong comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $abuse      = new Abuse($adapter);
 
 // Use vars to resolve adapter key
 
-if(!$abuse->check()) {
+if($abuse->check()) {
     throw new Exception('Service was abused!'); // throw error and return X-Rate limit headers here
 }
 ```
@@ -83,7 +83,7 @@ use Utopia\Abuse\Adapters\ReCaptcha;
 $adapter    = new ReCaptcha('secret-api-key', $_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
 $abuse      = new Abuse($adapter);
 
-if(!$abuse->check()) {
+if($abuse->check()) {
     throw new Exception('Service was abused!'); // throw error and return X-Rate limit headers here
 }
 ```


### PR DESCRIPTION
According to the [Appwrite usage of Abuse](https://github.com/appwrite/appwrite/blob/181741d7a2082f5c9d3ca727384601f3cf75e5bf/app/controllers/shared/api.php#LL164C22-L164C22), exception should be thrown when `check` returns true.