### PR TITLE
Remove deprecated curl_close calls

### DIFF
--- a/src/Abuse/Adapters/ReCaptcha.php
+++ b/src/Abuse/Adapters/ReCaptcha.php
@@ -80,7 +80,6 @@ class ReCaptcha extends Adapter
         /** @var array<string, mixed> $result */
         $result = \json_decode((string) \curl_exec($ch), true);
 
-        //close connection
         if ($result['success'] && $result['score'] >= $score) {
             return true;
         } else {

--- a/src/Abuse/Adapters/ReCaptcha.php
+++ b/src/Abuse/Adapters/ReCaptcha.php
@@ -81,7 +81,6 @@ class ReCaptcha extends Adapter
         $result = \json_decode((string) \curl_exec($ch), true);
 
         //close connection
-        \curl_close($ch);
         if ($result['success'] && $result['score'] >= $score) {
             return true;
         } else {


### PR DESCRIPTION
## What does this PR do?

Removes calls to `curl_close()`. Since PHP 8.0, cURL handles are `CurlHandle` objects and `curl_close()` no longer has an effect; handles are released by object lifetime instead. Removing these calls avoids noisy PHP 8.5 deprecation warnings without changing behavior for supported PHP versions.

## Test Plan

- Ran `php -l` on changed PHP files where applicable.
- Confirmed no `curl_close(...)` calls remain in this repository.

## Related PRs and Issues

N/A

### Have you read the Contributing Guidelines on issues?

Yes.
