### PR TITLE
feat: bump appwrite/appwrite to 24.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-curl": "*",
         "ext-redis": "*",
         "utopia-php/database": "5.*",
-        "appwrite/appwrite": "23.*"
+        "appwrite/appwrite": "24.*"
     },
     "require-dev": {
         "phpunit/phpunit": "9.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b04b14bd2ea9045a6b56b7aa930aea9f",
+    "content-hash": "c5a86c0dbd34a49a1f91118323c731c1",
     "packages": [
         {
             "name": "appwrite/appwrite",
-            "version": "23.1.0",
+            "version": "24.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/appwrite/sdk-for-php.git",
-                "reference": "2f275921f10ceb7cff99f2d463f7328b296234fa"
+                "reference": "dcb3550a3332de1c1665a015a09e9c73ff515e4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/appwrite/sdk-for-php/zipball/2f275921f10ceb7cff99f2d463f7328b296234fa",
-                "reference": "2f275921f10ceb7cff99f2d463f7328b296234fa",
+                "url": "https://api.github.com/repos/appwrite/sdk-for-php/zipball/dcb3550a3332de1c1665a015a09e9c73ff515e4f",
+                "reference": "dcb3550a3332de1c1665a015a09e9c73ff515e4f",
                 "shasum": ""
             },
             "require": {
@@ -43,10 +43,10 @@
             "support": {
                 "email": "team@appwrite.io",
                 "issues": "https://github.com/appwrite/sdk-for-php/issues",
-                "source": "https://github.com/appwrite/sdk-for-php/tree/23.1.0",
+                "source": "https://github.com/appwrite/sdk-for-php/tree/24.1.0",
                 "url": "https://appwrite.io/support"
             },
-            "time": "2026-05-08T13:44:58+00:00"
+            "time": "2026-05-20T09:37:03+00:00"
         },
         {
             "name": "brick/math",


### PR DESCRIPTION
Bumps the `appwrite/appwrite` PHP SDK constraint from `23.*` to `24.*` so downstream consumers (e.g. `utopia-php/migration`) can pull in the 24.x SDK without dependency conflicts.

## What's safe about this bump

The SDK 24.0.0 release introduced breaking changes — renamed `Project`-prefixed enums (`AuthMethod` → `ProjectAuthMethodId`, `ServiceId` → `ProjectServiceId`, `ProtocolId` → `ProjectProtocolId`, `ProjectPolicy` → `ProjectPolicyId`) — and 24.1.0 made `BillingLimits` inner fields nullable.

Abuse doesn't use any of the renamed symbols. Confirmed imports across `src/`:

```php
use Appwrite\AppwriteException;
use Appwrite\Client;
use Appwrite\Enums\TablesDBIndexType;
use Appwrite\ID;
use Appwrite\Models\Row;
use Appwrite\Query;
use Appwrite\Services\TablesDB;
```

`TablesDBIndexType` was renamed back in 21.0.0 (`IndexType` split) and is stable in both 23.x and 24.x. All other symbols are unchanged.

## Verification

- `composer update appwrite/appwrite -W` resolves cleanly; lock updated to **24.1.0**
- `php -l src/Abuse/Adapters/TimeLimit/Appwrite/TablesDB.php` passes
- `composer check` (phpstan level max) reports **No errors** on `src/`

## Motivation

`utopia-php/migration` is bumping to 24.* on its `add-policies-migration` branch ([PR #186](https://github.com/utopia-php/migration/pull/186)) to pick up the BillingLimits nullable fix (which was crashing project-level migrations) and the new `Project::get()` / `Project::getPolicy()` methods. Right now, cloud's composer tree can't resolve migration@24.* alongside abuse@1.3.0 because of this constraint. Bumping here unblocks the chain.