### PR TITLE
Add circuit breaker support to RedisPool

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "ext-curl": "*",
         "ext-redis": "*",
         "utopia-php/database": "^6.0.0",
+        "utopia-php/circuit-breaker": "0.3.*",
         "utopia-php/pools": "1.*",
         "appwrite/appwrite": "^26.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb890a101e6cacd0317970c692b16083",
+    "content-hash": "081f7ab870b7ac0f095032dc2c42a78e",
     "packages": [
         {
             "name": "appwrite/appwrite",

--- a/src/Abuse/Adapters/TimeLimit/RedisPool.php
+++ b/src/Abuse/Adapters/TimeLimit/RedisPool.php
@@ -5,6 +5,7 @@ namespace Utopia\Abuse\Adapters\TimeLimit;
 use RuntimeException;
 use Throwable;
 use Utopia\Abuse\Adapters\TimeLimit;
+use Utopia\CircuitBreaker\CircuitBreaker;
 use Utopia\Pools\Pool as UtopiaPool;
 
 class RedisPool extends TimeLimit
@@ -21,13 +22,32 @@ class RedisPool extends TimeLimit
         string $key,
         int $limit,
         int $seconds,
-        protected UtopiaPool $pool
+        protected UtopiaPool $pool,
+        protected ?CircuitBreaker $breaker = null
     ) {
         $this->key = $key;
         $this->ttl = $seconds;
         $now = \time();
         $this->timestamp = (int) ($now - ($now % $seconds));
         $this->limit = $limit;
+    }
+
+    /**
+     * @template T
+     * @param callable(\Redis|\RedisCluster): T $operation
+     * @param T $fallback
+     * @return T
+     */
+    private function guard(callable $operation, mixed $fallback): mixed
+    {
+        if ($this->breaker === null) {
+            return $this->pool->use($operation);
+        }
+
+        return $this->breaker->call(
+            open: fn (): mixed => $fallback,
+            close: fn (): mixed => $this->pool->use($operation),
+        );
     }
 
     protected function count(string $key, int $timestamp): int
@@ -41,11 +61,11 @@ class RedisPool extends TimeLimit
         }
 
         /** @var int $count */
-        $count = $this->pool->use(function (\Redis|\RedisCluster $redis) use ($key, $timestamp): int {
+        $count = $this->guard(function (\Redis|\RedisCluster $redis) use ($key, $timestamp): int {
             $count = $redis->get(Redis::NAMESPACE . '__' . $key . '__' . $timestamp);
 
             return \is_numeric($count) ? (int) $count : 0;
-        });
+        }, 0);
 
         $this->count = $count;
 
@@ -61,7 +81,7 @@ class RedisPool extends TimeLimit
         $ttl = $this->ttl;
         $key = Redis::NAMESPACE . '__' . $key . '__' . $timestamp;
 
-        $this->pool->use(function (\Redis|\RedisCluster $redis) use ($key, $ttl): void {
+        $this->guard(function (\Redis|\RedisCluster $redis) use ($key, $ttl): void {
             $redis->multi();
             try {
                 $redis->incr($key);
@@ -76,7 +96,7 @@ class RedisPool extends TimeLimit
                 $this->discard($redis);
                 throw new RuntimeException('Redis transaction failed.');
             }
-        });
+        }, null);
 
         $this->count = ($this->count ?? 0) + 1;
     }
@@ -86,7 +106,7 @@ class RedisPool extends TimeLimit
         $ttl = $this->ttl;
         $key = Redis::NAMESPACE . '__' . $key . '__' . $timestamp;
 
-        $this->pool->use(function (\Redis|\RedisCluster $redis) use ($key, $ttl, $value): void {
+        $this->guard(function (\Redis|\RedisCluster $redis) use ($key, $ttl, $value): void {
             $redis->multi();
             try {
                 $redis->set($key, (string) $value);
@@ -101,7 +121,7 @@ class RedisPool extends TimeLimit
                 $this->discard($redis);
                 throw new RuntimeException('Redis transaction failed.');
             }
-        });
+        }, null);
 
         $this->count = $value;
     }
@@ -121,7 +141,7 @@ class RedisPool extends TimeLimit
         $limit = $limit ?? 25;
 
         /** @var array<string, mixed> $result */
-        $result = $this->pool->use(function (\Redis|\RedisCluster $redis) use ($offset, $limit): array {
+        $result = $this->guard(function (\Redis|\RedisCluster $redis) use ($offset, $limit): array {
             if ($redis instanceof \RedisCluster) {
                 return $this->getRedisClusterLogs($redis, $offset, $limit);
             }
@@ -150,7 +170,7 @@ class RedisPool extends TimeLimit
             }
 
             return $logs;
-        });
+        }, []);
 
         return $result;
     }

--- a/tests/Abuse/RedisPoolCircuitBreakerTest.php
+++ b/tests/Abuse/RedisPoolCircuitBreakerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Utopia\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Abuse\Abuse;
+use Utopia\Abuse\Adapters\TimeLimit\RedisPool;
+use Utopia\CircuitBreaker\CircuitBreaker;
+use Utopia\Pools\Adapter\Stack;
+use Utopia\Pools\Pool;
+
+class RedisPoolCircuitBreakerTest extends TestCase
+{
+    public function testCircuitBreakerFailsOpenWhenPoolUnavailable(): void
+    {
+        $pool = new Pool(new Stack(), 'abuse-redis-unavailable', 1, function (): \Redis {
+            throw new \Exception('Redis unavailable');
+        });
+        $pool
+            ->setReconnectAttempts(1)
+            ->setRetryAttempts(1);
+
+        /** @var Pool<\Redis> $pool */
+        $adapter = new RedisPool(
+            'redis-pool-unavailable',
+            1,
+            60,
+            $pool,
+            new CircuitBreaker()
+        );
+
+        $abuse = new Abuse($adapter);
+
+        $this->assertFalse($abuse->check());
+        $this->assertSame([], $adapter->getLogs());
+    }
+}


### PR DESCRIPTION
﻿## Summary
- allow `RedisPool` to accept an optional circuit breaker
- fail open with fallback values when breaker-wrapped Redis pool operations fail
- add coverage for unavailable pool behavior

## Tests
- `php -l src/Abuse/Adapters/TimeLimit/RedisPool.php`
- `php -l tests/Abuse/RedisPoolCircuitBreakerTest.php`
- `vendor\bin\phpunit.bat --filter RedisPoolCircuitBreakerTest`
- `composer lint`
- `composer format`
- `composer check`
- `composer validate --strict --no-check-publish`
- `git diff --check`
